### PR TITLE
Fire events when queries are found

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ If you use **Lumen**, you need to copy the config file manually and register the
 $this->app->register(\BeyondCode\QueryDetector\LumenQueryDetectorServiceProvider::class);
 ```
 
+If you need additional logic to run when the package detects unoptimized queries, you can listen to the `\BeyondCode\QueryDetector\Events\QueryDetected` event and write a listener to run your own handler. (e.g. send warning to Sentry/Bugsnag, send Slack notification, etc.)
+
 ### Testing
 
 ``` bash

--- a/src/Events/QueryDetected.php
+++ b/src/Events/QueryDetected.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace BeyondCode\QueryDetector\Events;
+
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+
+class QueryDetected {
+    use SerializesModels;
+
+    /** @var Collection */
+    protected $queries;
+
+    public function __construct(Collection $queries)
+    {
+        $this->queries = $queries;
+    }
+
+    /**
+     * @return Collection
+     */
+    public function getQueries()
+    {
+        return $this->queries;
+    }
+}

--- a/src/QueryDetector.php
+++ b/src/QueryDetector.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Builder;
 use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use BeyondCode\QueryDetector\Events\QueryDetected;
 
 class QueryDetector
 {
@@ -167,7 +168,13 @@ class QueryDetector
             }
         }
 
-        return $queries->where('count', '>', config('querydetector.threshold', 1))->values();
+        $queries = $queries->where('count', '>', config('querydetector.threshold', 1))->values();
+
+        if ($queries->isNotEmpty()) {
+            event(new QueryDetected($queries));
+        }
+
+        return $queries;
     }
 
     protected function applyOutput(Response $response)


### PR DESCRIPTION
This PR updated the package to fire events when there are unoptimized queries, so the developer can listen to them and do anything with them (send warning to Sentry, Bugsnag, send message to Slack, etc).