### PR TITLE
Fixed a bug where output classes could be incorrectly instantiated by the framework

### DIFF
--- a/src/QueryDetector.php
+++ b/src/QueryDetector.php
@@ -172,14 +172,14 @@ class QueryDetector
 
     protected function applyOutput(Response $response)
     {
-        $outputTypes = app(config('querydetector.output'));
+        $outputTypes = config('querydetector.output');
 
         if (! is_array($outputTypes)) {
-            $types = [$outputTypes];
+            $outputTypes = [$outputTypes];
         }
 
         foreach ($outputTypes as $type) {
-            $type->output($this->getDetectedQueries(), $response);
+            app($type)->output($this->getDetectedQueries(), $response);
         }
     }
 


### PR DESCRIPTION
Laravel does not accept passing an array to `app()`, so unless you'd set up your config file with a single output classname expressed as a string, you were going to get an error.

This PR fixes that.

See https://github.com/beyondcode/laravel-query-detector/issues/14