### PR TITLE
Fix output of relationship name in advice part of alert

### DIFF
--- a/src/Outputs/Alert.php
+++ b/src/Outputs/Alert.php
@@ -37,7 +37,7 @@ class Alert implements Output
         $output .= "alert('Found the following N+1 queries in this request:\\n\\n";
         foreach ($detectedQueries as $detectedQuery) {
             $output .= "Model: ".addslashes($detectedQuery['model']). " => Relation: ".addslashes($detectedQuery['relation']);
-            $output .= " - You should add \"with(\'".$detectedQuery['relation']."\')\" to eager-load this relation.";
+            $output .= " - You should add \"with(\'".addslashes($detectedQuery['relation'])."\')\" to eager-load this relation.";
             $output .= "\\n";
         }
         $output .= "')";


### PR DESCRIPTION
Namespace \ was getting eaten.

fixes part of #9