### PR TITLE
Expanded the console log warning with the same details as the laravel.log

### DIFF
--- a/src/Outputs/Alert.php
+++ b/src/Outputs/Alert.php
@@ -36,7 +36,7 @@ class Alert implements Output
         $output = '<script type="text/javascript">';
         $output .= "alert('Found the following N+1 queries in this request:\\n\\n";
         foreach ($detectedQueries as $detectedQuery) {
-            $output .= "Model: ".addslashes($detectedQuery['model']). " => Relation: ".addslashes($detectedQuery['relation']);
+            $output .= "Model: ".addslashes($detectedQuery['model'])." => Relation: ".addslashes($detectedQuery['relation']);
             $output .= " - You should add \"with(\'".addslashes($detectedQuery['relation'])."\')\" to eager-load this relation.";
             $output .= "\\n";
         }

--- a/src/Outputs/Console.php
+++ b/src/Outputs/Console.php
@@ -27,9 +27,18 @@ class Console implements Output
         $output = '<script type="text/javascript">';
         $output .= "console.warn('Found the following N+1 queries in this request:\\n\\n";
         foreach ($detectedQueries as $detectedQuery) {
-            $output .= "Model: ".addslashes($detectedQuery['model']). " => Relation: ".addslashes($detectedQuery['relation']);
-            $output .= " - You should add \"with(\'".$detectedQuery['relation']."\')\" to eager-load this relation.";
+            $output .= "Model: " . addslashes($detectedQuery['model']) . " => Relation: " . addslashes($detectedQuery['relation']);
+            $output .= " - You should add \"with(\'" . $detectedQuery['relation'] . "\')\" to eager-load this relation.";
+            $output .= "\\n\\n";
+            $output .= "Model: " . addslashes($detectedQuery['model']) . "\\n";
+            $output .= "Relation: " . $detectedQuery['relation'] . "\\n";
+            $output .= "Num-Called: " . $detectedQuery['count'] . "\\n";
             $output .= "\\n";
+            $output .= 'Call-Stack:\\n';
+
+            foreach ($detectedQuery['sources'] as $source) {
+                $output .= "#$source->index $source->name:$source->line\\n";
+            }
         }
         $output .= "')";
         $output .= '</script>';

--- a/src/Outputs/Console.php
+++ b/src/Outputs/Console.php
@@ -27,12 +27,12 @@ class Console implements Output
         $output = '<script type="text/javascript">';
         $output .= "console.warn('Found the following N+1 queries in this request:\\n\\n";
         foreach ($detectedQueries as $detectedQuery) {
-            $output .= "Model: " . addslashes($detectedQuery['model']) . " => Relation: " . addslashes($detectedQuery['relation']);
-            $output .= " - You should add \"with(\'" . $detectedQuery['relation'] . "\')\" to eager-load this relation.";
+            $output .= "Model: ".addslashes($detectedQuery['model'])." => Relation: ".addslashes($detectedQuery['relation']);
+            $output .= " - You should add \"with(\'".$detectedQuery['relation']."\')\" to eager-load this relation.";
             $output .= "\\n\\n";
-            $output .= "Model: " . addslashes($detectedQuery['model']) . "\\n";
-            $output .= "Relation: " . $detectedQuery['relation'] . "\\n";
-            $output .= "Num-Called: " . $detectedQuery['count'] . "\\n";
+            $output .= "Model: ".addslashes($detectedQuery['model'])."\\n";
+            $output .= "Relation: ".$detectedQuery['relation']."\\n";
+            $output .= "Num-Called: ".$detectedQuery['count']."\\n";
             $output .= "\\n";
             $output .= 'Call-Stack:\\n';
 


### PR DESCRIPTION
I have expanded the information given in the console warning to have the same level of details as the Log output. This way you don't have to dive into the log each time to find the precise file and line that the query is on. It's all available in the front-end.