### PR TITLE
Fix issues with Debugbar output when used with SPAs/ajax requests

### DIFF
--- a/src/Outputs/Alert.php
+++ b/src/Outputs/Alert.php
@@ -7,6 +7,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 class Alert implements Output
 {
+    public function boot()
+    {
+        //
+    }
+
     public function output(Collection $detectedQueries, Response $response)
     {
         if (stripos($response->headers->get('Content-Type'), 'text/html') !== 0 || $response->isRedirection()) {

--- a/src/Outputs/Console.php
+++ b/src/Outputs/Console.php
@@ -7,6 +7,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 class Console implements Output
 {
+    public function boot()
+    {
+        //
+    }
+
     public function output(Collection $detectedQueries, Response $response)
     {
         if (stripos($response->headers->get('Content-Type'), 'text/html') !== 0 || $response->isRedirection()) {

--- a/src/Outputs/Debugbar.php
+++ b/src/Outputs/Debugbar.php
@@ -10,18 +10,23 @@ use DebugBar\DataCollector\MessagesCollector;
 
 class Debugbar implements Output
 {
+    protected $collector;
+
+    public function boot()
+    {
+        $this->collector = new MessagesCollector('N+1 Queries');
+
+        LaravelDebugbar::addCollector($this->collector);
+    }
+
     public function output(Collection $detectedQueries, Response $response)
     {
-        $collector = new MessagesCollector('N+1 Queries');
-
         foreach ($detectedQueries as $detectedQuery) {
-            $collector->addMessage(sprintf('Model: %s => Relation: %s - You should add `with(%s)` to eager-load this relation.',
+            $this->collector->addMessage(sprintf('Model: %s => Relation: %s - You should add `with(%s)` to eager-load this relation.',
                 $detectedQuery['model'],
                 $detectedQuery['relation'],
                 $detectedQuery['relation']
             ));
         }
-
-        LaravelDebugbar::addCollector($collector);
     }
 }

--- a/src/Outputs/Json.php
+++ b/src/Outputs/Json.php
@@ -7,6 +7,10 @@ use Illuminate\Http\JsonResponse;
 
 class Json implements Output
 {
+    public function boot()
+    {
+        //
+    }
 
     public function output(Collection $detectedQueries, Response $response)
     {

--- a/src/Outputs/Log.php
+++ b/src/Outputs/Log.php
@@ -8,6 +8,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 class Log implements Output
 {
+    public function boot()
+    {
+        //
+    }
+
     public function output(Collection $detectedQueries, Response $response)
     {
         LaravelLog::info('Detected N+1 Query');

--- a/src/Outputs/Output.php
+++ b/src/Outputs/Output.php
@@ -7,5 +7,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 interface Output
 {
+    public function boot();
+
     public function output(Collection $detectedQueries, Response $response);
 }

--- a/src/QueryDetector.php
+++ b/src/QueryDetector.php
@@ -26,6 +26,11 @@ class QueryDetector
 
             $this->logQuery($query, $backtrace);
         });
+
+        foreach ($this->getOutputTypes() as $outputType) {
+            app()->singleton($outputType);
+            app($outputType)->boot();
+        }
     }
 
     public function isEnabled(): bool
@@ -179,7 +184,7 @@ class QueryDetector
         return $queries;
     }
 
-    protected function applyOutput(Response $response)
+    protected function getOutputTypes()
     {
         $outputTypes = config('querydetector.output');
 
@@ -187,7 +192,12 @@ class QueryDetector
             $outputTypes = [$outputTypes];
         }
 
-        foreach ($outputTypes as $type) {
+        return $outputTypes;
+    }
+
+    protected function applyOutput(Response $response)
+    {
+        foreach ($this->getOutputTypes() as $type) {
             app($type)->output($this->getDetectedQueries(), $response);
         }
     }


### PR DESCRIPTION
Debugbar's UI only shows tabs for MessageCollectors added during the initial page load. Previously, the N+1 Queries MessageCollector was only added to Debugbar when N+1 queries were actually detected. This meant that if no queries were detected on the initial page load, but they were detected during subsequent requests made via JS, those queries wouldn't show up because the tab wouldn't appear within Debugbar.

This change adds a `boot` method to the `Output` interface and registers each output method as a singleton (so we can retain a reference to the message collector added during boot). The message collector is added to Debugbar during boot regardless of whether there will be messages displayed in it, which fixes issues with requests loaded via JS.