### PR TITLE
fix: dont add the collector to debugbar twice

### DIFF
--- a/src/Outputs/Debugbar.php
+++ b/src/Outputs/Debugbar.php
@@ -15,8 +15,10 @@ class Debugbar implements Output
     public function boot()
     {
         $this->collector = new MessagesCollector('N+1 Queries');
-
-        LaravelDebugbar::addCollector($this->collector);
+        
+        if (!LaravelDebugbar::hasCollector($this->collector->getName())) {
+            LaravelDebugbar::addCollector($this->collector);
+        }
     }
 
     public function output(Collection $detectedQueries, Response $response)


### PR DESCRIPTION
fixes https://github.com/beyondcode/laravel-query-detector/issues/34