### PR TITLE
Fix Facade usage

### DIFF
--- a/src/Outputs/Debugbar.php
+++ b/src/Outputs/Debugbar.php
@@ -5,7 +5,7 @@ namespace BeyondCode\QueryDetector\Outputs;
 use Illuminate\Support\Collection;
 use Symfony\Component\HttpFoundation\Response;
 
-use Debugbar as LaravelDebugbar;
+use Barryvdh\Debugbar\Facade as LaravelDebugbar;
 use DebugBar\DataCollector\MessagesCollector;
 
 class Debugbar implements Output


### PR DESCRIPTION
If someone (like me) doesn't allow Debugbar to be auto-discovered by Laravel, the Facade might not be aliased to `Debugbar`. The exception `Class 'Debugbar' not found` would be thrown.