### PR TITLE
use FQCN for Log and DB facade import

### DIFF
--- a/src/Outputs/Log.php
+++ b/src/Outputs/Log.php
@@ -2,7 +2,7 @@
 
 namespace BeyondCode\QueryDetector\Outputs;
 
-use Log as LaravelLog;
+use Illuminate\Support\Facades\Log as LaravelLog;
 use Illuminate\Support\Collection;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/QueryDetector.php
+++ b/src/QueryDetector.php
@@ -2,7 +2,7 @@
 
 namespace BeyondCode\QueryDetector;
 
-use DB;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Builder;
 use Symfony\Component\HttpFoundation\Response;


### PR DESCRIPTION
Currently the package relies on there being a global `DB` facade alias being registered, if you remove that from your `config/app.php` this package will stop working.