### PR TITLE
Prevent Illegal string offset 'warning_queries'

### DIFF
--- a/src/Outputs/Json.php
+++ b/src/Outputs/Json.php
@@ -16,6 +16,10 @@ class Json implements Output
     {
         if ($response instanceof JsonResponse) {
             $data = $response->getData(true);
+            if (! is_array($data)){
+                $data = [ $data ];
+            }
+            
             $data['warning_queries'] = $detectedQueries;
             $response->setData($data);
         }


### PR DESCRIPTION
Prevent Illegal string offset 'warning_queries' exception from not Arrayable responses.

**Exception**
`message: "Method Illuminate\Support\Collection::__toString() must not throw an exception, caught ErrorException: Illegal string offset 'warning_queries'"
exception: "Symfony\Component\Debug\Exception\FatalErrorException"
file: "vendor/beyondcode/laravel-query-detector/src/Outputs/Json.php"
line: 0`

**Original response**
<img width="656" alt="Print screen" src="https://user-images.githubusercontent.com/1950715/74976212-53ba4d00-53f6-11ea-8ee7-95ccd7f35f3e.png">
