### PR TITLE
Avoid namespace conflicts

### DIFF
--- a/src/Outputs/Log.php
+++ b/src/Outputs/Log.php
@@ -2,7 +2,7 @@
 
 namespace BeyondCode\QueryDetector\Outputs;
 
-use Log as LaravelLog;
+use Illuminate\Support\Facades\Log as LaravelLog;
 use Illuminate\Support\Collection;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/QueryDetector.php
+++ b/src/QueryDetector.php
@@ -2,7 +2,7 @@
 
 namespace BeyondCode\QueryDetector;
 
-use DB;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Builder;


### PR DESCRIPTION
We are using Laravel components/packages in a different framework. The global namespaces DB and Log cause some conflicts with our framework, so in order to use this package, we need to use Facade instead of global namespace.

The test failure doesn't seem related to this.