### PR TITLE
Fixed typo in threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ return [
      * Threshold level for the N+1 query detection. If a relation query will be
      * executed more then this amount, the detector will notify you about it.
      */
-    'threshold' => (int) env('QUERY_DETECTOR_TRESHOLD', 1),
+    'threshold' => (int) env('QUERY_DETECTOR_THRESHOLD', 1),
 
     /*
      * Here you can whitelist model relations.

--- a/config/config.php
+++ b/config/config.php
@@ -11,7 +11,7 @@ return [
      * Threshold level for the N+1 query detection. If a relation query will be
      * executed more then this amount, the detector will notify you about it.
      */
-    'threshold' => (int) env('QUERY_DETECTOR_TRESHOLD', 1),
+    'threshold' => (int) env('QUERY_DETECTOR_THRESHOLD', 1),
 
     /*
      * Here you can whitelist model relations.


### PR DESCRIPTION
Just fixed a typo in the `QUERY_DETECTOR_THRESHOLD` environment variable.