### PR TITLE
allow for query logger to write to different logs

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -6,7 +6,7 @@ return [
      * If this is set to "null", the app.debug config value will be used.
      */
     'enabled' => env('QUERY_DETECTOR_ENABLED', null),
-    
+
     /*
      * Threshold level for the N+1 query detection. If a relation query will be
      * executed more then this amount, the detector will notify you about it.
@@ -26,6 +26,13 @@ return [
         //    'posts',
         //]
     ],
+
+    /*
+     * Here you can set a specific log channel to write to
+     * in case you are trying to isolate queries or have a lot
+     * going on in the laravel.log. Defaults to laravel.log though.
+     */
+    'log_channel' => env('QUERY_DETECTOR_LOG_CHANNEL', 'daily'),
 
     /*
      * Define the output format that you want to use. Multiple classes are supported.

--- a/src/Outputs/Log.php
+++ b/src/Outputs/Log.php
@@ -15,22 +15,27 @@ class Log implements Output
 
     public function output(Collection $detectedQueries, Response $response)
     {
-        LaravelLog::info('Detected N+1 Query');
+        $this->log('Detected N+1 Query');
 
         foreach ($detectedQueries as $detectedQuery) {
             $logOutput = 'Model: '.$detectedQuery['model'] . PHP_EOL;
-            
+
             $logOutput .= 'Relation: '.$detectedQuery['relation'] . PHP_EOL;
 
             $logOutput .= 'Num-Called: '.$detectedQuery['count'] . PHP_EOL;
-            
+
             $logOutput .= 'Call-Stack:' . PHP_EOL;
 
             foreach ($detectedQuery['sources'] as $source) {
                 $logOutput .= '#'.$source->index.' '.$source->name.':'.$source->line . PHP_EOL;
             }
 
-            LaravelLog::info($logOutput);
+            $this->log($logOutput);
         }
+    }
+
+    private function log(string $message)
+    {
+        LaravelLog::channel(config('querydetector.log_channel'))->info($message);
     }
 }


### PR DESCRIPTION
Fantastic package that has been useful for me today. I thought it would be good though to allow the logging to be more configurable and allow someone to choose where the logs from the Query Logger end up, in case `laravel.log` is a mess or they are trying to just keep things nice and neat. 