### PR TITLE
Support php 8

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,5 +1,12 @@
 filter:
     excluded_paths: [tests/*]
+    
+build:
+    nodes:
+        analysis:
+            tests:
+                override:
+                    - php-scrutinizer-run
 
 checks:
     php:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
 
 env:
   - LARAVEL="^5.5" COMPOSER_FLAGS="--prefer-lowest"
@@ -13,6 +14,8 @@ env:
   - LARAVEL="^6.0" COMPOSER_FLAGS=""
   - LARAVEL="^7.0" COMPOSER_FLAGS="--prefer-lowest"
   - LARAVEL="^7.0" COMPOSER_FLAGS=""
+  - LARAVEL="^8.0" COMPOSER_FLAGS="--prefer-lowest"
+  - LARAVEL="^8.0" COMPOSER_FLAGS=""
 
 matrix:
   exclude:
@@ -24,11 +27,20 @@ matrix:
       env: LARAVEL="^7.0" COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.1
       env: LARAVEL="^7.0" COMPOSER_FLAGS=""
+    - php: 7.1
+      env: LARAVEL="^8.0" COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.1
+      env: LARAVEL="^8.0" COMPOSER_FLAGS=""
   allow_failures:
     - php: 7.4
       env: LARAVEL="^5.5" COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.4
       env: LARAVEL="^6.0" COMPOSER_FLAGS="--prefer-lowest"
+    - php: 8.0
+      env: LARAVEL="^5.5" COMPOSER_FLAGS="--prefer-lowest"
+    - php: 8.0
+      env: LARAVEL="^6.0" COMPOSER_FLAGS="--prefer-lowest"
+
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8.0",
         "illuminate/support": "^5.5 || ^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR adds support for PHP 8

Migrate to new PHP Analysis in scrutinizer build.
https://scrutinizer-ci.com/docs/tools/php/php-analyzer/guides/migrate_to_new_php_analysis