### PR TITLE
Refactor, Tiny Enhancements and Bug Fixes

### DIFF
--- a/src/Concerns/Bootable.php
+++ b/src/Concerns/Bootable.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace BeyondCode\QueryDetector\Concerns;
+
+trait Bootable
+{
+    /** @var bool */
+    protected $booted = false;
+
+    /**
+     * Safely boot if wasn't booted before
+     *
+     * @return void
+     */
+    public function bootIfNotBooted() : void
+    {
+        if ($this->isBooted()) {
+            return;
+        }
+
+        $this->boot();
+        $this->booted();
+    }
+
+    /**
+     * Runs after "boot"
+     *
+     * @return void
+     */
+    protected function booted() : void
+    {
+        $this->booted = true;
+    }
+
+    /**
+     * Determine if already booted
+     *
+     * @return bool
+     */
+    public function isBooted()
+    {
+        return $this->booted;
+    }
+
+    protected function boot() : void
+    {
+    }
+}

--- a/src/Concerns/HasContext.php
+++ b/src/Concerns/HasContext.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace BeyondCode\QueryDetector\Concerns;
+
+use Illuminate\Support\Str;
+
+trait HasContext
+{
+    /** @var string */
+    protected $context = 'querydetector';
+
+    /**
+     * Set specific context for the executed queries.
+     *
+     * @param string $context
+     * @return self
+     */
+    public function setContext(string $context): self
+    {
+        $this->context = $context;
+
+        return $this;
+    }
+
+    /**
+     * Get the current context name
+     *
+     * @param string $context
+     * @return self
+     */
+    public function getContext(): string
+    {
+        return $this->context;
+    }
+
+    /**
+     * Generate a new context for the executed queries.
+     *
+     * @return self
+     */
+    public function newContext(): self
+    {
+        $this->setContext(Str::random());
+
+        return $this;
+    }
+}

--- a/src/Concerns/InteractsWithSourceFiles.php
+++ b/src/Concerns/InteractsWithSourceFiles.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace BeyondCode\QueryDetector\Concerns;
+
+trait InteractsWithSourceFiles
+{
+    protected function findSource($stack)
+    {
+        $sources = [];
+
+        foreach ($stack as $index => $trace) {
+            $sources[] = $this->parseTrace($index, $trace);
+        }
+
+        return array_values(array_filter($sources));
+    }
+
+    public function parseTrace($index, array $trace)
+    {
+        $frame = (object) [
+            'index' => $index,
+            'name' => null,
+            'line' => isset($trace['line']) ? $trace['line'] : '?',
+        ];
+
+        if (isset($trace['class']) &&
+            isset($trace['file']) &&
+            !$this->fileIsInExcludedPath($trace['file'])
+        ) {
+            $frame->name = $this->normalizeFilename($trace['file']);
+
+            return $frame;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if the given file is to be excluded from analysis
+     *
+     * @param string $file
+     * @return bool
+     */
+    protected function fileIsInExcludedPath($file)
+    {
+        $excludedPaths = [
+            '/vendor/laravel/framework/src/Illuminate/Database',
+            '/vendor/laravel/framework/src/Illuminate/Events',
+        ];
+
+        $normalizedPath = str_replace('\\', '/', $file);
+
+        foreach ($excludedPaths as $excludedPath) {
+            if (strpos($normalizedPath, $excludedPath) !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Shorten the path by removing the relative links and base dir
+     *
+     * @param string $path
+     * @return string
+     */
+    protected function normalizeFilename($path): string
+    {
+        if (file_exists($path)) {
+            $path = realpath($path);
+        }
+
+        return str_replace(base_path(), '', $path);
+    }
+}

--- a/src/QueryDetector.php
+++ b/src/QueryDetector.php
@@ -4,20 +4,18 @@ namespace BeyondCode\QueryDetector;
 
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Builder;
 use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use BeyondCode\QueryDetector\Events\QueryDetected;
 use BeyondCode\QueryDetector\Concerns\Bootable;
+use BeyondCode\QueryDetector\Concerns\HasContext;
 use BeyondCode\QueryDetector\Concerns\InteractsWithSourceFiles;
 
 class QueryDetector
 {
-    use Bootable, InteractsWithSourceFiles;
-    /** @var string */
-    protected $context = 'querydetector';
+    use Bootable, HasContext, InteractsWithSourceFiles;
 
     /** @var Collection */
     private $queries;
@@ -99,42 +97,6 @@ class QueryDetector
                 ];
             }
         }
-    }
-
-    /**
-     * Set specific context for the executed queries.
-     *
-     * @param string $context
-     * @return self
-     */
-    public function setContext(string $context): self
-    {
-        $this->context = $context;
-
-        return $this;
-    }
-
-    /**
-     * Get the current context name
-     *
-     * @param string $context
-     * @return self
-     */
-    public function getContext(): string
-    {
-        return $this->context;
-    }
-
-    /**
-     * Generate a new context for the executed queries.
-     *
-     * @return self
-     */
-    public function newContext(): self
-    {
-        $this->setContext(Str::random());
-
-        return $this;
     }
 
     public function getDetectedQueries(): Collection

--- a/src/QueryDetector.php
+++ b/src/QueryDetector.php
@@ -16,6 +16,9 @@ class QueryDetector
     /** @var string */
     protected $context = 'querydetector';
 
+    /** @var bool */
+    protected $booted = false;
+
     /** @var Collection */
     private $queries;
 
@@ -24,7 +27,7 @@ class QueryDetector
         $this->queries = Collection::make();
     }
 
-    public function boot()
+    protected function boot()
     {
         DB::listen(function($query) {
             $backtrace = collect(debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 50));
@@ -36,6 +39,41 @@ class QueryDetector
             app()->singleton($outputType);
             app($outputType)->boot();
         }
+    }
+
+    /**
+     * Safely boot if wasn't booted before
+     *
+     * @return void
+     */
+    public function bootIfNotBooted() : void
+    {
+        if ($this->isBooted()) {
+            return;
+        }
+
+        $this->boot();
+        $this->booted();
+    }
+
+    /**
+     * Runs after "boot"
+     *
+     * @return void
+     */
+    protected function booted() : void
+    {
+        $this->booted = true;
+    }
+
+    /**
+     * Determine if already booted
+     *
+     * @return bool
+     */
+    public function isBooted()
+    {
+        return $this->booted;
     }
 
     public function isEnabled(): bool

--- a/src/QueryDetector.php
+++ b/src/QueryDetector.php
@@ -10,14 +10,13 @@ use Illuminate\Database\Eloquent\Builder;
 use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use BeyondCode\QueryDetector\Events\QueryDetected;
+use BeyondCode\QueryDetector\Concerns\Bootable;
 
 class QueryDetector
 {
+    use Bootable;
     /** @var string */
     protected $context = 'querydetector';
-
-    /** @var bool */
-    protected $booted = false;
 
     /** @var Collection */
     private $queries;
@@ -39,41 +38,6 @@ class QueryDetector
             app()->singleton($outputType);
             app($outputType)->boot();
         }
-    }
-
-    /**
-     * Safely boot if wasn't booted before
-     *
-     * @return void
-     */
-    public function bootIfNotBooted() : void
-    {
-        if ($this->isBooted()) {
-            return;
-        }
-
-        $this->boot();
-        $this->booted();
-    }
-
-    /**
-     * Runs after "boot"
-     *
-     * @return void
-     */
-    protected function booted() : void
-    {
-        $this->booted = true;
-    }
-
-    /**
-     * Determine if already booted
-     *
-     * @return bool
-     */
-    public function isBooted()
-    {
-        return $this->booted;
     }
 
     public function isEnabled(): bool

--- a/src/QueryDetector.php
+++ b/src/QueryDetector.php
@@ -11,10 +11,11 @@ use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use BeyondCode\QueryDetector\Events\QueryDetected;
 use BeyondCode\QueryDetector\Concerns\Bootable;
+use BeyondCode\QueryDetector\Concerns\InteractsWithSourceFiles;
 
 class QueryDetector
 {
-    use Bootable;
+    use Bootable, InteractsWithSourceFiles;
     /** @var string */
     protected $context = 'querydetector';
 
@@ -98,76 +99,6 @@ class QueryDetector
                 ];
             }
         }
-    }
-
-    protected function findSource($stack)
-    {
-        $sources = [];
-
-        foreach ($stack as $index => $trace) {
-            $sources[] = $this->parseTrace($index, $trace);
-        }
-
-        return array_values(array_filter($sources));
-    }
-
-    public function parseTrace($index, array $trace)
-    {
-        $frame = (object) [
-            'index' => $index,
-            'name' => null,
-            'line' => isset($trace['line']) ? $trace['line'] : '?',
-        ];
-
-        if (isset($trace['class']) &&
-            isset($trace['file']) &&
-            !$this->fileIsInExcludedPath($trace['file'])
-        ) {
-            $frame->name = $this->normalizeFilename($trace['file']);
-
-            return $frame;
-        }
-
-        return false;
-    }
-
-    /**
-     * Check if the given file is to be excluded from analysis
-     *
-     * @param string $file
-     * @return bool
-     */
-    protected function fileIsInExcludedPath($file)
-    {
-        $excludedPaths = [
-            '/vendor/laravel/framework/src/Illuminate/Database',
-            '/vendor/laravel/framework/src/Illuminate/Events',
-        ];
-
-        $normalizedPath = str_replace('\\', '/', $file);
-
-        foreach ($excludedPaths as $excludedPath) {
-            if (strpos($normalizedPath, $excludedPath) !== false) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Shorten the path by removing the relative links and base dir
-     *
-     * @param string $path
-     * @return string
-     */
-    protected function normalizeFilename($path): string
-    {
-        if (file_exists($path)) {
-            $path = realpath($path);
-        }
-
-        return str_replace(base_path(), '', $path);
     }
 
     /**

--- a/src/QueryDetector.php
+++ b/src/QueryDetector.php
@@ -134,17 +134,19 @@ class QueryDetector
         return $outputTypes;
     }
 
-    protected function applyOutput(Response $response)
+    protected function applyOutput(Collection $detectedQueries, Response $response)
     {
         foreach ($this->getOutputTypes() as $type) {
-            app($type)->output($this->getDetectedQueries(), $response);
+            app($type)->output($detectedQueries, $response);
         }
     }
 
     public function output($request, $response)
     {
-        if ($this->getDetectedQueries()->isNotEmpty()) {
-            $this->applyOutput($response);
+        $detectedQueries = $this->getDetectedQueries();
+
+        if ($detectedQueries->isNotEmpty()) {
+            $this->applyOutput($detectedQueries, $response);
         }
 
         return $response;

--- a/src/QueryDetectorMiddleware.php
+++ b/src/QueryDetectorMiddleware.php
@@ -32,6 +32,8 @@ class QueryDetectorMiddleware
         /** @var \Illuminate\Http\Response $response */
         $response = $next($request);
 
+        $this->detector->newContext();
+
         // Modify the response to add the Debugbar
         $this->detector->output($request, $response);
 

--- a/src/QueryDetectorMiddleware.php
+++ b/src/QueryDetectorMiddleware.php
@@ -27,7 +27,7 @@ class QueryDetectorMiddleware
             return $next($request);
         }
 
-        $this->detector->boot();
+        $this->detector->bootIfNotBooted();
 
         /** @var \Illuminate\Http\Response $response */
         $response = $next($request);

--- a/tests/QueryDetectorTest.php
+++ b/tests/QueryDetectorTest.php
@@ -244,6 +244,24 @@ class QueryDetectorTest extends TestCase
 
         Event::assertDispatched(QueryDetected::class);
     }
+    /** @test */
+    public function it_uses_different_context_for_each_request()
+    {
+        Route::get('/', function (){
+            $authors = Author::all();
+
+            foreach ($authors as $author) {
+                $author->profile;
+            }
+        });
+
+        $this->get('/');
+        $this->get('/');
+
+        $queries = app(QueryDetector::class)->getDetectedQueries();
+
+        $this->assertCount(2, collect($queries)->pluck('context')->unique());
+    }
 
     /** @test */
     public function it_does_not_fire_an_event_if_there_is_no_n1_query()

--- a/tests/QueryDetectorTest.php
+++ b/tests/QueryDetectorTest.php
@@ -242,7 +242,7 @@ class QueryDetectorTest extends TestCase
 
         $this->get('/');
 
-        Event::assertDispatched(QueryDetected::class);
+        Event::assertDispatched(QueryDetected::class, 1);
     }
     /** @test */
     public function it_uses_different_context_for_each_request()


### PR DESCRIPTION
Hello @mpociot 

Thanks for this package, Smart and neat! .. Used it in one project where it allowed me to fix N+1 issues in bulk throughout the code base, a real time saver. Thank you!


---

Without a breaking change, This PR includes the following:

### - Basic code refactor

Targeting `src/QueryDetector.php`, Using Concerns traits, Return early if statements.

> Commits:
> 
> 5f2dfd686b5da2691e174e20df488abe5b50b005 Refactor to Return Early if statements
> 033258340db5d3eb4d4170a8ea1a38405d899114 Refactor to `HasContext` Concern
> 11bc17b6710ade8b186643c879fd0a92f8a2f41c Refactor to `InteractsWithSourceFiles` Concern
> 946d1ea3ad94d8ee911d1cd9cfce0acb71e57e31 Refactor to `Bootable` Concern

---

### - Adaptability to multiple-requests contexts

Possibly closes: #70 
Possibly closes: #71 

#### Problem:

What I mean by multiple requests contexts, when we do multiple requests/responses lifecycles within one Laravel container `app()` instance.

Commonly this happens in Feature/Integration tests. Where we might do multiple requests inside one test.

To even simplify the problem, We already have in our unit tests this passing test:
``` php
    /** @test */
    public function it_does_not_fire_an_event_if_there_is_no_n1_query()
    {
        Event::fake();

        Route::get('/', function (){
            $authors = Author::with('profile')->get();

            foreach ($authors as $author) {
                $author->profile;
            }
        });

        $this->get('/');

        Event::assertNotDispatched(QueryDetected::class);
    }
```

**If we just duplicated the visit `$this->get('/'); $this->get('/');`, it will fail and it will claim we are having N+1 issue.**

#### Solution:

This was solved by adding a `$context` variable to be part of the calculated query key. So the key now includes the `context` variable, and we will automatically register a new random string context after each request.

The key will be (In `src/QueryDetector.php`) :
``` php
$key = md5($this->context . $query->sql . $model . $relationName . $sources[0]->name . $sources[0]->line);
```

And in the middleware we will register a new context after each request. (In `src/QueryDetectorMiddleware.php`) :
``` php
        /** @var \Illuminate\Http\Response $response */
        $response = $next($request);

        $this->detector->newContext();

        // Modify the response to add the Debugbar
        $this->detector->output($request, $response);
```

Now, a userland code for isolating queries in dispatched jobs might look something like this:

``` php
        Event::listen(function (JobProcessing $jobProcessingEvent) {
            app('querydetector')->newContext();
        });
```

> Commits:
> a691bc2f801cacf530c213e8d9222808d1bac900 Always clear context after requests
> 7e370ddbb3fc0bf2d38dad876f0e6fc33becd8d8 Add Contexts Feature

---

### - Other Bug Fixes and Enhancements

While working on this `context` feature, I had to solve some older issues.

1. Bug: Booting multiple times.

The code in the middleware before executing the request:

``` php
$this->detector->boot();
```

Now it's

``` php
$this->detector->bootIfNotBooted();
```

Since `booting` multiple times means registering multiple database listeners `DB::listen` since it's in the `boot` function.

> Commit: 0f692b58c066b52fd308a37dac94e688246c2198 Safely boot the service in controllable and manageable way

2. Dispatching multiple events

The code in `BeyondCode\QueryDetector\QueryDetector::output($request, $response)` function, which get called from the middleware, will call the function `getDetectedQueries` multiple times.

This function, `BeyondCode\QueryDetector\QueryDetector::getDetectedQueries`, encapsulates dispatching the event `QueryDetected`.

The solution was to call `getDetectedQueries` once and pass it's results around to the needed methods.

I considered extracting the event dispatch logic from `getDetectedQueries`, to prevent a "getSomething" method from performing any actions silently, but then I thought that should be for further development in a separate PR.

> Commit: a3ca8f2de87540895dd7792c52adb7e9b5b48f41 Fix dispatching multiple events
