### PR TITLE
Add slashes to relation strings in console output

### DIFF
--- a/src/Outputs/Console.php
+++ b/src/Outputs/Console.php
@@ -42,10 +42,10 @@ class Console implements Output
         $output .= "console.warn('Found the following N+1 queries in this request:\\n\\n";
         foreach ($detectedQueries as $detectedQuery) {
             $output .= "Model: ".addslashes($detectedQuery['model'])." => Relation: ".addslashes($detectedQuery['relation']);
-            $output .= " - You should add \"with(\'".$detectedQuery['relation']."\')\" to eager-load this relation.";
+            $output .= " - You should add \"with(\'".addslashes($detectedQuery['relation'])."\')\" to eager-load this relation.";
             $output .= "\\n\\n";
             $output .= "Model: ".addslashes($detectedQuery['model'])."\\n";
-            $output .= "Relation: ".$detectedQuery['relation']."\\n";
+            $output .= "Relation: ".addslashes($detectedQuery['relation'])."\\n";
             $output .= "Num-Called: ".$detectedQuery['count']."\\n";
             $output .= "\\n";
             $output .= 'Call-Stack:\\n';


### PR DESCRIPTION
Go from this:
```
Model: App\Models\Artist => Relation: App\Models\Image - You should add "with('AppModelsImage')" to eager-load this relation.

Model: App\Models\Artist
Relation: AppModelsImage
Num-Called: 416
```

to this:
```
Model: App\Models\Artist => Relation: App\Models\Image - You should add "with('App\Models\Image')" to eager-load this relation.

Model: App\Models\Artist
Relation: App\Models\Image
Num-Called: 416
```