### PR TITLE
Do not log if no valid sources are found in backtrace

### DIFF
--- a/src/QueryDetector.php
+++ b/src/QueryDetector.php
@@ -74,6 +74,10 @@ class QueryDetector
                 }
 
                 $sources = $this->findSource($backtrace);
+                
+                if (empty($sources)) {
+                    return;
+                }
 
                 $key = md5($query->sql . $model . $relationName . $sources[0]->name . $sources[0]->line);
 


### PR DESCRIPTION
This PR attempts to fix #91. When the backtrace results are filtered through `findSource`, they can return an empty array. 

Currently if the array is empty, an error is thrown as the zero key in `$sources` is not found.

This checks to see if the array is empty, if so, it simply returns from the log.

This PR may be a bit naïve in that I am not able to determine which use cases the backtrace is returning empty. There may be a deeper issue at play, however this returns before the error and allows the app to continue to function.

I also do not have a good way to test this, so if someone would like to add a test, feel free.