### PR TITLE
Support multiple requests

### DIFF
--- a/src/QueryDetector.php
+++ b/src/QueryDetector.php
@@ -14,15 +14,29 @@ class QueryDetector
 {
     /** @var Collection */
     private $queries;
+    /**
+     * @var bool
+     */
+    private $booted = false;
 
-    public function __construct()
+    private function resetQueries()
     {
         $this->queries = Collection::make();
     }
 
+    public function __construct()
+    {
+        $this->resetQueries();
+    }
+
     public function boot()
     {
-        DB::listen(function($query) {
+        if ($this->booted) {
+            $this->resetQueries();
+            return;
+        }
+
+        DB::listen(function ($query) {
             $backtrace = collect(debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 50));
 
             $this->logQuery($query, $backtrace);
@@ -32,6 +46,8 @@ class QueryDetector
             app()->singleton($outputType);
             app($outputType)->boot();
         }
+
+        $this->booted = true;
     }
 
     public function isEnabled(): bool
@@ -52,13 +68,13 @@ class QueryDetector
         });
 
         // The query is coming from an Eloquent model
-        if (! is_null($modelTrace)) {
+        if (!is_null($modelTrace)) {
             /*
              * Relations get resolved by either calling the "getRelationValue" method on the model,
              * or if the class itself is a Relation.
              */
             $relation = $backtrace->first(function ($trace) {
-                return Arr::get($trace, 'function') === 'getRelationValue' || Arr::get($trace, 'class') === Relation::class ;
+                return Arr::get($trace, 'function') === 'getRelationValue' || Arr::get($trace, 'class') === Relation::class;
             });
 
             // We try to access a relation
@@ -77,8 +93,8 @@ class QueryDetector
 
                 $key = md5($query->sql . $model . $relationName . $sources[0]->name . $sources[0]->line);
 
-                $count = Arr::get($this->queries, $key.'.count', 0);
-                $time = Arr::get($this->queries, $key.'.time', 0);
+                $count = Arr::get($this->queries, $key . '.count', 0);
+                $time = Arr::get($this->queries, $key . '.time', 0);
 
                 $this->queries[$key] = [
                     'count' => ++$count,
@@ -106,7 +122,7 @@ class QueryDetector
 
     public function parseTrace($index, array $trace)
     {
-        $frame = (object) [
+        $frame = (object)[
             'index' => $index,
             'name' => null,
             'line' => isset($trace['line']) ? $trace['line'] : '?',
@@ -191,7 +207,7 @@ class QueryDetector
     {
         $outputTypes = config('querydetector.output');
 
-        if (! is_array($outputTypes)) {
+        if (!is_array($outputTypes)) {
             $outputTypes = [$outputTypes];
         }
 


### PR DESCRIPTION
I use this tool specially in unit tests, and in unit tests sometimes you end up having multiple requests in a test (This isn't specifically related to unit tests, internal API calls for instance would suffer from the same problem.), your package was counting the previous queries from the previous requests in,  causing it to think n+1 queries exists since repeated queries exist regardless of the fact that those queries had happened in a different context (in the previous requests) so I made sure your package won't register multiple listeners or count in the stale queries from previous attempts.

So that's what this pull request does, 2 tests are written to ensure now multiple requests will work for detecting the n+1 queries and not detecting regular queries as n+1 queries.

That's all folks, that's in advance for considering this pull request.