### PR TITLE
fix: resolve Debugbar facade at runtime to support Barryvdh and Fruitcake implementations

### DIFF
--- a/src/Outputs/Debugbar.php
+++ b/src/Outputs/Debugbar.php
@@ -2,12 +2,9 @@
 
 namespace BeyondCode\QueryDetector\Outputs;
 
+use DebugBar\DataCollector\MessagesCollector;
 use Illuminate\Support\Collection;
 use Symfony\Component\HttpFoundation\Response;
-
-use Barryvdh\Debugbar\Facade as LaravelDebugbarV3;
-use DebugBar\DataCollector\MessagesCollector;
-use Fruitcake\LaravelDebugbar\Facades\Debugbar as LaravelDebugbar;
 
 class Debugbar implements Output
 {
@@ -17,26 +14,52 @@ class Debugbar implements Output
     {
         $this->collector = new MessagesCollector('N+1 Queries');
 
-        if (class_exists(\Fruitcake\LaravelDebugbar\Facades\Debugbar::class)) {
-            if (!LaravelDebugbar::hasCollector($this->collector->getName())) {
-                LaravelDebugbar::addCollector($this->collector);
-            }
+        $facade = $this->resolveDebugbarFacade();
+
+        if ($facade === null) {
             return;
         }
 
-        if (!LaravelDebugbarV3::hasCollector($this->collector->getName())) {
-            LaravelDebugbarV3::addCollector($this->collector);
+        if (! $facade::hasCollector($this->collector->getName())) {
+            $facade::addCollector($this->collector);
         }
     }
 
     public function output(Collection $detectedQueries, Response $response)
     {
         foreach ($detectedQueries as $detectedQuery) {
-            $this->collector->addMessage(sprintf('Model: %s => Relation: %s - You should add `with(%s)` to eager-load this relation.',
+            $this->collector->addMessage(sprintf(
+                'Model: %s => Relation: %s - You should add `with(%s)` to eager-load this relation.',
                 $detectedQuery['model'],
                 $detectedQuery['relation'],
                 $detectedQuery['relation']
             ));
         }
+    }
+
+    /**
+     * Resolve the installed Debugbar facade at runtime.
+     *
+     * Supports barryvdh/laravel-debugbar (v3 and v4+) and
+     * fruitcake/laravel-debugbar. Returns the first class
+     * that the autoloader can locate, or null if none exist.
+     *
+     * @return string|null
+     */
+    protected function resolveDebugbarFacade()
+    {
+        $candidates = [
+            'Barryvdh\Debugbar\Facades\Debugbar',
+            'Barryvdh\Debugbar\Facade',
+            'Fruitcake\LaravelDebugbar\Facades\Debugbar',
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (class_exists($candidate)) {
+                return $candidate;
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
 ## Summary

  The Debugbar output crashes with a fatal error when `fruitcake/laravel-debugbar`
  is installed instead of `barryvdh/laravel-debugbar`, or when neither is present.

  The existing code had a `class_exists` guard around the Fruitcake path but left
  the Barryvdh fallback completely unguarded — if the Fruitcake check fails and
  Barryvdh isn't installed either, the app 500s.

  ## Changes

  - Replaced hardcoded facade `use` imports and branching `if/else` with a single
    `resolveDebugbarFacade()` method that checks all known facade FQCNs via
    `class_exists()` and returns the first match
  - All code paths are now guarded; `boot()` early-returns if no Debugbar is found
  - Supports: `barryvdh/laravel-debugbar` v3, v4+, and `fruitcake/laravel-debugbar`
  - Adding support for future forks = one string in the `$candidates` array
  - No breaking changes, no new dependencies, PHP 7.1+ compatible

  ## Test plan

  - [ ] Install `barryvdh/laravel-debugbar` v3 — verify N+1 messages appear in Debugbar
  - [ ] Install `barryvdh/laravel-debugbar` v4+ — verify N+1 messages appear in Debugbar
  - [ ] Install `fruitcake/laravel-debugbar` — verify N+1 messages appear in Debugbar
  - [ ] Uninstall all Debugbar packages — verify no fatal error, output silently skipped
  - [ ] Install both Barryvdh and Fruitcake — verify Barryvdh takes precedence (first match)